### PR TITLE
chore: remove hardcoded secrets from HEAD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,27 +3,22 @@
 
 POSTGRES_DB=nexus
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=__REPLACE_WITH_SECURE_PASSWORD__
+POSTGRES_PASSWORD=<your_postgres_password_here>
 
-DJANGO_SECRET_KEY=__REPLACE_WITH_SECURE_RANDOM_KEY__
+# Django application secret key (use a secure random string in production)
+DJANGO_SECRET_KEY=<your_django_secret_key_here>
 DJANGO_DEBUG=1
 
 # Usage:
 # 1. Copy this file to `.env` in the project root.
 # 2. Fill in secure values for `POSTGRES_PASSWORD` and `DJANGO_SECRET_KEY`.
 # 3. Ensure `.env` is listed in `.gitignore` and not committed.
+
 # Local development environment variables
-# NOTE: Do NOT commit real secret values. This file is an example only.
-# For CI, configure secrets in GitHub Actions (see README "CI Secrets").
-DJANGO_SECRET_KEY=replace-with-secure-random-string
-DJANGO_DEBUG=1
 DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
 
 # Postgres settings for docker-compose
 POSTGRES_HOST=db
-POSTGRES_DB=nexus
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=__REPLACED_IN_PROD__
 POSTGRES_PORT=5432
 
 # JWT

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -6,8 +6,9 @@ from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
-# Non-sensitive test password used only in unit tests
-TEST_PASSWORD = 'test-pass-1'
+# Non-sensitive test password used only in unit tests. Prefer setting TEST_PASSWORD in CI or local env.
+import os
+TEST_PASSWORD = os.environ.get('TEST_PASSWORD', 'change-me-testing-password')
 
 
 class AuthTests(TestCase):


### PR DESCRIPTION
This PR removes hardcoded test secrets from HEAD and sanitizes .env.example. Secrets should be rotated and stored in CI or .env files that are .gitignored.