### PR TITLE
chore(ci): prefer PAGES_PAT for OpenAPI publish and document remediation

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -47,15 +47,20 @@ jobs:
           mkdir -p site
           mv openapi.html site/index.html
 
-      - name: Deploy to GitHub Pages (use PAGES_PAT if provided)
-        if: ${{ secrets.PAGES_PAT }}
+      - name: Detect publish token
+        id: detect-token
+        run: |
+          if [ -n "${{ secrets.PAGES_PAT }}" ]; then echo "use_pages_pat=true" >> $GITHUB_OUTPUT; else echo "use_pages_pat=false" >> $GITHUB_OUTPUT; fi
+
+      - name: Deploy to GitHub Pages (use PAGES_PAT)
+        if: steps.detect-token.outputs.use_pages_pat == 'true'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.PAGES_PAT }}
           publish_dir: ./site
 
       - name: Deploy to GitHub Pages (fallback to GITHUB_TOKEN)
-        if: ${{ !secrets.PAGES_PAT }}
+        if: steps.detect-token.outputs.use_pages_pat == 'false'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY_INCIDENT_UPDATE.md
+++ b/SECURITY_INCIDENT_UPDATE.md
@@ -64,3 +64,55 @@ Next steps I can take for you
 - Add an incident entry to the repo's `SECURITY_INCIDENT.md` (if you want this file replaced rather than creating an update file).
 
 Tell me which of the above you'd like me to do next.
+
+Remediation record (actions performed)
+-------------------------------------
+The following actions were performed to remediate the detected hardcoded secret without destructively rewriting the contributor's branch.
+
+- Created a fresh mirror clone and ran git-filter-repo to remove/replace the literal across history:
+
+```powershell
+# From local repo root
+mkdir .\repo-mirror2.git
+git clone --mirror --no-local . .\repo-mirror2.git
+Set-Content -Path .\secrets-to-remove.txt -Value "test-pass-1==>[REDACTED]"
+Set-Location -Path .\repo-mirror2.git
+python -m git_filter_repo --replace-text ..\secrets-to-remove.txt --force
+```
+
+- Created a working clone from the cleaned mirror, created a timestamped cleaned branch, and pushed it to origin:
+
+```powershell
+Set-Location -Path ..
+git clone .\repo-mirror2.git .\repo-cleaned2
+Set-Location -Path .\repo-cleaned2
+git checkout -b chore/add-precommit-hooks-clean-<TIMESTAMP>
+git remote add github https://github.com/enyasystem/alx-project-nexus.git
+git push github chore/add-precommit-hooks-clean-<TIMESTAMP>:chore/add-precommit-hooks-clean-<TIMESTAMP>
+```
+
+- Opened a PR from the cleaned branch and, after verifying GitGuardian and CI checks passed, merged the sanitized PR into `main`.
+
+   - Sanitized PR: https://github.com/enyasystem/alx-project-nexus/pull/12
+   - Merge commit: c963671583f1 (merged by @enyasystem)
+
+- I left a comment on the original PR (#10) explaining the remediation and linking to the sanitized PR and incident doc.
+
+Notes
+-----
+- This approach avoids force-pushing the contributor's branch. If you prefer to rewrite the original branch in place (force-push), I can prepare the full `git-filter-repo` commands and coordinate a maintenance window.
+- Even after history cleanup you must rotate/revoke the exposed credential if it was used anywhere.
+
+Publish workflow (OpenAPI) remediation
+-------------------------------------
+I inspected the failing OpenAPI publish workflow run (previous run id: 18044170813). The failure is consistent with a push/permission error when the workflow attempted to push built docs to the `gh-pages` branch.
+
+What I changed
+- Updated `.github/workflows/publish-openapi.yml` to detect whether a `PAGES_PAT` repo secret is present and to prefer it; otherwise the workflow falls back to using `GITHUB_TOKEN`.
+- The workflow now uses a `detect-token` step and selects the appropriate deploy step via step outputs to avoid runtime conditional pitfalls.
+
+Recommended final steps
+- Option A (recommended): Create a repository secret named `PAGES_PAT` containing a personal access token with the following scopes: `repo` and `workflow` (for private repos use `repo` scope; for public-only repos `public_repo` may be sufficient). Then re-run the publish workflow — it should be able to push and succeed.
+- Option B: If you prefer using `GITHUB_TOKEN` only, ensure repository settings allow GitHub Actions to write repository contents (Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests / read and write permissions). After that re-run the workflow.
+
+I can create a follow-up PR that tweaks the workflow further (for example add debugging output or a single-step deploy) if you want me to. 


### PR DESCRIPTION
This PR prefers a PAGES_PAT repository secret for publishing OpenAPI docs to gh-pages and documents the remediation steps taken for the GitGuardian finding. See SECURITY_INCIDENT_UPDATE.md for details.